### PR TITLE
修复 hiveserver2 启动加载 materialized view 时加载全量表

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -336,6 +336,39 @@ class MetaStoreDirectSql {
   }
 
   /**
+   * Get table names by using direct SQL queries.
+   *
+   * @param dbName Metastore database namme
+   * @param tableType Table type, or null if we want to get all tables
+   * @return list of table names
+   */
+  public List<String> getTables(String dbName, TableType tableType) throws MetaException {
+    List<String> ret = new ArrayList<String>();
+    String queryText = " select \"TBLS\".\"TBL_NAME\" "
+            + " from \"TBLS\" "
+            + " inner join \"DBS\" on \"TBLS\".\"DB_ID\" = \"DBS\".\"DB_ID\" "
+            + " where \"DBS\".\"NAME\" = ? "
+            + (tableType == null ? "" : " and \"TBLS\".\"TBL_TYPE\" = ? ");
+
+    List<String> pms = new ArrayList<String>();
+    pms.add(dbName);
+    if (tableType != null) {
+      pms.add(tableType.toString());
+    }
+
+    Query queryParams = pm.newQuery("javax.jdo.query.SQL", queryText);
+    List<Object[]> sqlResult = ensureList(executeWithArray(
+            queryParams, pms.toArray(), queryText));
+
+    if (!sqlResult.isEmpty()) {
+      for (Object[] line : sqlResult) {
+        ret.add(extractSqlString(line[0]));
+      }
+    }
+    return ret;
+  }
+
+  /**
    * Gets partitions by using direct SQL queries.
    * Note that batching is not needed for this method - list of names implies the batch size;
    * @param dbName Metastore db name.

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -1335,12 +1335,36 @@ public class Hive {
   /**
    * Get all tables for the specified database.
    * @param dbName
-   * @return List of table names
+   * @return List of all tables
    * @throws HiveException
    */
   public List<Table> getAllTableObjects(String dbName) throws HiveException {
+    return getTableObjects(dbName, ".*", null);
+  }
+
+  /**
+   * Get all materialized view names for the specified database.
+   * @param dbName
+   * @return List of materialized view table names
+   * @throws HiveException
+   */
+  public List<String> getAllMaterializedViews(String dbName) throws HiveException {
+    return getTablesByType(dbName, ".*", TableType.MATERIALIZED_VIEW);
+  }
+
+  /**
+   * Get all materialized views for the specified database.
+   * @param dbName
+   * @return List of materialized view table objects
+   * @throws HiveException
+   */
+  public List<Table> getAllMaterializedViewObjects(String dbName) throws HiveException {
+    return getTableObjects(dbName, ".*", TableType.MATERIALIZED_VIEW);
+  }
+
+  private List<Table> getTableObjects(String dbName, String pattern, TableType tableType) throws HiveException {
     try {
-      return Lists.transform(getMSC().getTableObjectsByName(dbName, getMSC().getAllTables(dbName)),
+      return Lists.transform(getMSC().getTableObjectsByName(dbName, getTablesByType(dbName, pattern, tableType)),
         new com.google.common.base.Function<org.apache.hadoop.hive.metastore.api.Table, Table>() {
           @Override
           public Table apply(org.apache.hadoop.hive.metastore.api.Table table) {
@@ -1444,7 +1468,7 @@ public class Hive {
       List<RelOptMaterialization> result = new ArrayList<>();
       for (String dbName : getMSC().getAllDatabases()) {
         // From metastore (for security)
-        List<String> tables = getMSC().getAllTables(dbName);
+        List<String> tables = getAllMaterializedViews(dbName);
         // Cached views (includes all)
         Collection<RelOptMaterialization> cachedViews =
             HiveMaterializedViewsRegistry.get().getRewritingMaterializedViews(dbName);

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
@@ -119,32 +119,28 @@ public final class HiveMaterializedViewsRegistry {
    * it does.
    */
   public void init(final Hive db) {
-    try {
-      List<Table> tables = new ArrayList<Table>();
-      for (String dbName : db.getAllDatabases()) {
-        // TODO: We should enhance metastore API such that it returns only
-        // materialized views instead of all tables
-        tables.addAll(db.getAllTableObjects(dbName));
-      }
-      pool.submit(new Loader(tables));
-    } catch (HiveException e) {
-      LOG.error("Problem connecting to the metastore when initializing the view registry");
-    }
+    pool.submit(new Loader(db));
   }
 
   private class Loader implements Runnable {
-    private final List<Table> tables;
+    private final Hive db;
 
-    private Loader(List<Table> tables) {
-      this.tables = tables;
+    private Loader(Hive db) {
+      this.db = db;
     }
 
     @Override
     public void run() {
-      for (Table table : tables) {
-        if (table.isMaterializedView()) {
-          addMaterializedView(table);
+      try {
+        List<Table> materializedViews = new ArrayList<Table>();
+        for (String dbName : db.getAllDatabases()) {
+          materializedViews.addAll(db.getAllMaterializedViewObjects(dbName));
         }
+        for (Table mv : materializedViews) {
+          addMaterializedView(mv);
+        }
+      } catch (HiveException e) {
+        LOG.error("Problem connecting to the metastore when initializing the view registry");
       }
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMaterializedViewsRegistry.java
@@ -132,6 +132,9 @@ public final class HiveMaterializedViewsRegistry {
     @Override
     public void run() {
       try {
+        SessionState ss = new SessionState(db.getConf());
+        ss.setIsHiveServerQuery(true); // All is served from HS2, we do not need e.g. Tez sessions
+        SessionState.start(ss);
         List<Table> materializedViews = new ArrayList<Table>();
         for (String dbName : db.getAllDatabases()) {
           materializedViews.addAll(db.getAllMaterializedViewObjects(dbName));


### PR DESCRIPTION
1. 修复 hiveserver2 启动加载 materialized view 时加载全量表。
2. 修复加载 materialized view 时没有初始化 SessionState 导致的 NullPointerException。